### PR TITLE
data ophalen at runtime ipv at build time

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,7 +5,7 @@ import styles from '@/styles/Home.module.css'
 
 const inter = Inter({ subsets: ['latin'] })
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
 
   try {
     // todo change to https://sel2-4.ugent.be on server


### PR DESCRIPTION
frontend/index.tsx gebruikt nu getServerSideProps in plaats van getStaticProps(). Hierdoor wordt de data at runtime opgehaald in plaats van at build time