### PR TITLE
fix max function over empty sequence error. 

### DIFF
--- a/backend/manual/views.py
+++ b/backend/manual/views.py
@@ -16,13 +16,16 @@ class Default(APIView):
         if not building or not file:
             return Response('"building" and "file" fields are required',
                             status.HTTP_400_BAD_REQUEST)
-        if not version:
-            # latest version ophalen
-            instances = Manual.objects.all()
-            version = max([instance.version_number for instance in instances]) + 1
         candidates = Building.objects.filter(id=building)
         if len(candidates) != 1:
             return Response('"Building" field was not valid', status=status.HTTP_400_BAD_REQUEST)
+        if not version:
+            # latest version ophalen
+            instances = Manual.objects.filter(building=candidates[0])
+            if len(instances) == 0:
+                version = 1
+            else:
+                version = max([instance.version_number for instance in instances]) + 1
         pb = Manual(building=candidates[0], file=file, version_number=version)
         try:
             pb.full_clean()
@@ -67,6 +70,7 @@ class ManualView(APIView):
         except ValidationError as e:
             return Response(e.message_dict, status=status.HTTP_400_BAD_REQUEST)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
 
 class ManualBuildingView(APIView):
     def get(self, request, building_id):


### PR DESCRIPTION
Error when automatically assigning a version number to an uploaded pdf. This occurs when there are no manuals in de database yet for the given building. Solution was checking if there are already manuals in the system or not.
The `.all()` was also replaced with a `.filter(Building=instance)` because versioning is only relevant for a single building, no need to max over all available buildings.