### PR TITLE
Removed 'IsAuthenticated' for token refresh

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -54,7 +54,6 @@ class LogoutViewWithBlacklisting(LogoutView):
 
 
 class RefreshViewHiddenTokens(TokenRefreshView):
-    permission_classes = [IsAuthenticated]
     serializer_class = CookieTokenRefreshSerializer
 
     def finalize_response(self, request, response, *args, **kwargs):


### PR DESCRIPTION
You don't need to be authenticated to be able to refresh your token.