### PR TITLE
open port 2002 to backend for a nicer ui

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -57,4 +57,13 @@ http {
 #         ssl_certificate_key '/etc/letsencrypt/live/sel2-4.ugent.be/privkey.pem';
 #         include /etc/letsencrypt/options-ssl-nginx.conf;
     }
+
+    server {
+        listen 2002;
+        server_name localhost;
+        location / {
+            proxy_pass         http://docker-backend;
+            proxy_redirect     off;
+        }
+    }
 }


### PR DESCRIPTION
This PR opens port 2002 to backend django for easy of development, this port will be closed in production.