### PR TITLE
fix trailing / on root of api

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,7 +28,7 @@ http {
         listen 80 default_server;
         listen [::]:80;
         # for development purposes
-        location ~ ^/api/(?<rest>.*)$ {
+        location ~ ^/api(/?|/(?<rest>.*))$ {
             proxy_pass     http://docker-backend/$rest;
         }
         location / {


### PR DESCRIPTION
this PR allows to leave out the trailing `/` on the root of the api for conveniences