### PR TITLE
Error handling when adding inactive email to lobby (fixes #125)

### DIFF
--- a/backend/base/models.py
+++ b/backend/base/models.py
@@ -13,7 +13,7 @@ from users.managers import UserManager
 
 # sys.maxsize throws psycopg2.errors.NumericValueOutOfRange: integer out of range
 # Set the max int manually
-MAX_INT = 2 ** 31 - 1
+MAX_INT = 2**31 - 1
 
 
 class Region(models.Model):
@@ -212,7 +212,7 @@ class GarbageCollection(models.Model):
                 "date",
                 name="garbage_collection_unique",
                 violation_error_message="This type of garbage is already being collected on the same day for this "
-                                        "building.",
+                "building.",
             ),
         ]
 
@@ -386,9 +386,9 @@ class Manual(models.Model):
         max_version_number = max(version_numbers)
 
         if (
-                self.version_number == 0
-                or self.version_number > max_version_number + 1
-                or self.version_number in version_numbers
+            self.version_number == 0
+            or self.version_number > max_version_number + 1
+            or self.version_number in version_numbers
         ):
             self.version_number = max_version_number + 1
 


### PR DESCRIPTION
POST a user (you can still do that, in the near future we will probably remove this?)

![image](https://user-images.githubusercontent.com/71405687/227646388-de2ac28a-882c-4695-a98f-8a7aff257db5.png)

--------------------------------

DELETE the user

![image](https://user-images.githubusercontent.com/71405687/227646441-c030467b-32fb-4b95-a7c0-41b25b9a25c1.png)


------------------------

When doing GET on this user, you can see that `is_active` is set to false.

![image](https://user-images.githubusercontent.com/71405687/227646544-df193d4e-4265-44dd-b1f4-311b1236f148.png)


--------------------------

Try adding the email of this user to the Lobby

![image](https://user-images.githubusercontent.com/71405687/227646622-131c0362-51a2-4666-a3cd-3cde2906bbbb.png)


You can see this is a different error handling than when you try to add an active email to Lobby

![image](https://user-images.githubusercontent.com/71405687/227646730-3fdf6746-a941-4e71-b8b9-f3a4977e3f8e.png)






Closes #125

