### PR TITLE
Added a query parameter to fetch only the latest manual from a building (fixes #298)

### DIFF
--- a/backend/manual/views.py
+++ b/backend/manual/views.py
@@ -96,9 +96,9 @@ class ManualBuildingView(APIView):
         parameters=param_docs(
             {
                 "most-recent": (
-                        "When set to 'true', only the most recent manual will be returned",
-                        False,
-                        OpenApiTypes.BOOL,
+                    "When set to 'true', only the most recent manual will be returned",
+                    False,
+                    OpenApiTypes.BOOL,
                 )
             }
         ),


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/71405687/230742376-5addb500-b223-4aa2-8d05-0362021b0e7e.png)



![image](https://user-images.githubusercontent.com/71405687/230742396-0a7f2252-d968-4a04-8804-df72cef04051.png)






-------------------------------------------------------------------------------------------------------------------
* @jonathancasters, because of the way I retrieve the most recent manual (`.order_by("-version_number")`), I don't think I can use your abstractians?
* @sevrijss, I manually ran your tests, they still work. I don't know whether you will write tests for query parameters or if it is my job know everytime I change something in the database. If you are tired of writing test, you can write tests for the query parameters of one route. I can look for the rest.



closes #298
