### PR TITLE
#118 fixed swagger requests

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -86,7 +86,7 @@ SPECTACULAR_SETTINGS = {
     "DESCRIPTION": "This is the documentation for the Dr-Trottoir API",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
-    'SCHEMA_PATH_PREFIX_INSERT': '/api',
+    "SCHEMA_PATH_PREFIX_INSERT": "/api",
     # OTHER SETTINGS
 }
 


### PR DESCRIPTION
Fixes #118

It is now possible to perform API requests through the Swagger UI. This didn't work before because the requests URLs were missing the `/api` prefix which has now been added.