### PR TITLE
fixed dependabot access to repository secrets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Test Code Base
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - develop
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.events.pull_request.head.repo.full_name }}
       
       - name: Build Docker
         run: docker-compose build


### PR DESCRIPTION
I noticed that dependabot wasn't able to access the repository secrets. These are needed in order to build the test database in docker, which it could not do, resulting in a failed check on dependabot's PR's. 

This approach should fix this issue. I am unable to test this however, as I can't make dependabot PR's myself. I will check up on this if dependabot made some new PR's.