### PR TITLE
Added public building info page for residents (fixes #398)

### DIFF
--- a/backend/base/models.py
+++ b/backend/base/models.py
@@ -119,7 +119,7 @@ class Building(models.Model):
     syndic = models.ForeignKey(User, on_delete=models.SET_NULL, blank=True, null=True)
     region = models.ForeignKey(Region, on_delete=models.SET_NULL, blank=True, null=True)
     name = models.CharField(max_length=100, blank=True, null=True)
-    public_id = models.CharField(max_length=32, blank=True, null=True)
+    public_id = models.CharField(max_length=32, blank=True, null=True, unique=True)
 
     """
     Only a syndic can own a building, not a student.

--- a/frontend/components/building/BuildingPage.tsx
+++ b/frontend/components/building/BuildingPage.tsx
@@ -1,18 +1,19 @@
-import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
-import { BuildingInterface, getBuildingInfo } from "@/lib/building";
-import { AxiosResponse } from "axios/index";
+import {useRouter} from "next/router";
+import React, {useEffect, useState} from "react";
+import {BuildingInterface, getBuildingInfo, getBuildingInfoByPublicId} from "@/lib/building";
+import {AxiosResponse} from "axios/index";
 import BuildingInfo from "@/components/building/buildingComponents/BuildingInfo";
 import LatestCollectionDetail from "@/components/building/buildingComponents/LatestCollectionDetail";
 import LatestCollections from "@/components/building/buildingComponents/LatestCollections";
 
-interface ParsedUrlQuery {}
+interface ParsedUrlQuery {
+}
 
 interface DashboardQuery extends ParsedUrlQuery {
     id?: string;
 }
 
-function BuildingPage({ type }: { type: "syndic" | "admin" | "" }) {
+function BuildingPage({type}: { type: "syndic" | "admin" | "public" }) {
     const router = useRouter();
     const query = router.query as DashboardQuery;
 
@@ -20,13 +21,23 @@ function BuildingPage({ type }: { type: "syndic" | "admin" | "" }) {
     const [building, setBuilding] = useState<BuildingInterface>(null);
 
     async function fetchBuilding() {
-        getBuildingInfo(Number(query.id))
-            .then((buildings: AxiosResponse<any>) => {
-                setBuilding(buildings.data);
-            })
-            .catch((error) => {
-                console.error(error);
-            });
+        if (type !== "public" /*&& /^\d+$/.test(query.id+"")*/) {
+            getBuildingInfo(Number(query.id))
+                .then((buildings: AxiosResponse) => {
+                    setBuilding(buildings.data);
+                })
+                .catch((error) => {
+                    console.error(error);  //TODO: error component?
+                });
+        } else {
+            getBuildingInfoByPublicId(query.id)
+                .then((buildings: AxiosResponse) => {
+                    setBuilding(buildings.data);
+                })
+                .catch((error) => {
+                    console.error(error);
+                });
+        }
     }
 
     useEffect(() => {
@@ -40,15 +51,15 @@ function BuildingPage({ type }: { type: "syndic" | "admin" | "" }) {
 
     return (
         <>
-            <div style={{ display: "flex" }}>
-                <div style={{ flex: "1" }}>
-                    <BuildingInfo building={building} setBuilding={setBuilding} type={type} />
+            <div style={{display: "flex"}}>
+                <div style={{flex: "1"}}>
+                    <BuildingInfo building={building} setBuilding={setBuilding} type={type}/>
                 </div>
-                <div style={{ flex: "1" }}>
-                    <LatestCollectionDetail building={building ? building.id : 0} />
+                <div style={{flex: "1"}}>
+                    <LatestCollectionDetail building={building ? building.id : 0}/>
                 </div>
-                <div style={{ flex: "1" }}>
-                    <LatestCollections building={building ? building.id : 0} />
+                <div style={{flex: "1"}}>
+                    <LatestCollections building={building ? building.id : 0}/>
                 </div>
             </div>
         </>

--- a/frontend/components/building/buildingComponents/BuildingInfo.tsx
+++ b/frontend/components/building/buildingComponents/BuildingInfo.tsx
@@ -91,7 +91,7 @@ function BuildingInfo({
             <p>Straat: {get_building_key("street")}</p>
             <p>Nr: {get_building_key("house_number")}</p>
             <p>Bus: {get_building_key("bus")}</p>
-            <p>RegionInterface: {regionName} </p>
+            <p>Region: {regionName} </p>
             <p>Werktijd: {get_building_key("duration")}</p>
             <p>Client id: {get_building_key("client_id")}</p>
             <p>Public id: {get_building_key("public_id")}</p>

--- a/frontend/components/building/buildingComponents/BuildingInfo.tsx
+++ b/frontend/components/building/buildingComponents/BuildingInfo.tsx
@@ -1,19 +1,18 @@
-import { TiPencil } from "react-icons/ti";
-import React, { useEffect, useState } from "react";
+import {TiPencil} from "react-icons/ti";
+import React, {useEffect, useState} from "react";
 import PatchBuildingSyndicModal from "@/components/building/buildingComponents/editModals/PatchBuildingSyndicModal";
-import { BuildingInterface } from "@/lib/building";
-import { getRegion, RegionInterface } from "@/lib/region";
-import PatchBuildingAdminModal from "@/components/building/buildingComponents/editModals/PatchBuildingAdminModal";
-import { useRouter } from "next/router";
+import {BuildingInterface} from "@/lib/building";
+import {getRegion} from "@/lib/region";
+import {useRouter} from "next/router";
 
 function BuildingInfo({
-    building,
-    setBuilding,
-    type,
-}: {
+                          building,
+                          setBuilding,
+                          type,
+                      }: {
     building: BuildingInterface;
     setBuilding: (b: any) => void;
-    type: "syndic" | "admin" | "";
+    type: "syndic" | "admin" | "public";
 }) {
     const router = useRouter();
     const [editBuilding, setEditBuilding] = useState(false);
@@ -76,13 +75,15 @@ function BuildingInfo({
 
             <h1>
                 Gebouw{" "}
-                <TiPencil
-                    className={"clickable"}
-                    onClick={(e) => {
-                        e.preventDefault();
-                        setEditBuilding(true);
-                    }}
-                ></TiPencil>
+                {type == "syndic" ? (
+                    <TiPencil
+                        className={"clickable"}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            setEditBuilding(true);
+                        }}
+                    ></TiPencil>
+                ) : null}
             </h1>
             <p>ID: {get_building_key("id")} </p>
             <p>Naam: {get_building_key("name")}</p>

--- a/frontend/components/building/buildingComponents/editModals/PatchBuildingSyndicModal.tsx
+++ b/frontend/components/building/buildingComponents/editModals/PatchBuildingSyndicModal.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
-import { withAuthorisation } from "@/components/withAuthorisation";
-import { Button, Form, Modal } from "react-bootstrap";
-import { BuildingInterface, BuildingSyndicPostInterface } from "@/lib/building";
+import React, {useEffect, useState} from "react";
+import {withAuthorisation} from "@/components/withAuthorisation";
+import {Button, Form, Modal} from "react-bootstrap";
+import {BuildingInterface, BuildingSyndicPostInterface} from "@/lib/building";
 import {
     getNewPublicIdUtil,
     handleInputChangeUtil,
@@ -9,11 +9,11 @@ import {
 } from "@/components/building/buildingComponents/editModals/handleUtil";
 
 function PatchBuildingSyndicModal({
-    show,
-    closeModal,
-    building,
-    setBuilding,
-}: {
+                                      show,
+                                      closeModal,
+                                      building,
+                                      setBuilding,
+                                  }: {
     show: boolean;
     closeModal: () => void;
     building: BuildingInterface | null;
@@ -89,11 +89,11 @@ function PatchBuildingSyndicModal({
                                 <a
                                     href={
                                         building?.public_id
-                                            ? `${process.env.NEXT_PUBLIC_HOST}public/building/${building?.public_id}`
-                                            : "#"
+                                            ? `/public/building?id=${building?.public_id}`
+                                            : ""
                                     }
                                 >
-                                    {`${process.env.NEXT_PUBLIC_HOST}public/building/${
+                                    {`${process.env.NEXT_PUBLIC_HOST}/public/building?id=${
                                         building?.public_id ? building?.public_id : "<public_id>"
                                     }`}
                                 </a>
@@ -101,7 +101,7 @@ function PatchBuildingSyndicModal({
                         </Form.Group>
 
                         {/*TODO: below line should probably a custom component with a state boolean*/}
-                        <div style={{ background: "red" }}>{errorText}</div>
+                        <div style={{background: "red"}}>{errorText}</div>
 
                         <Button
                             variant="danger"

--- a/frontend/lib/building.ts
+++ b/frontend/lib/building.ts
@@ -45,6 +45,11 @@ export const getBuildingInfo = async (buildingId: string | undefined | number): 
     return await api.get(request_url);
 };
 
+export const getBuildingInfoByPublicId = async (publicId: string | undefined | number): Promise<AxiosResponse<any>> => {
+    const request_url: string = `${process.env.NEXT_PUBLIC_BASE_API_URL}${process.env.NEXT_PUBLIC_API_PUBLIC_ID_BUILDING}${publicId}`;
+    return await api.get(request_url);
+}
+
 export async function getAllBuildings(): Promise<AxiosResponse<any>> {
     const request_url: string = `${process.env.NEXT_PUBLIC_BASE_API_URL}${process.env.NEXT_PUBLIC_API_ALL_BUILDINGS}`;
     return await api.get(request_url);

--- a/frontend/pages/public/building.tsx
+++ b/frontend/pages/public/building.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import BuildingPage from "@/components/building/BuildingPage";
+import BaseHeader from "@/components/header/baseHeader";
+
+function PublicBuilding() {
+
+    return (
+        <>
+            <BaseHeader/>
+            <BuildingPage type={""}/>
+        </>
+    )
+
+}
+
+export default PublicBuilding;
+

--- a/frontend/pages/public/building.tsx
+++ b/frontend/pages/public/building.tsx
@@ -2,16 +2,13 @@ import React from "react";
 import BuildingPage from "@/components/building/BuildingPage";
 import BaseHeader from "@/components/header/baseHeader";
 
-
 function PublicBuilding() {
-
     return (
         <>
-            <BaseHeader/>
-            <BuildingPage type={"public"}/>
+            <BaseHeader />
+            <BuildingPage type={"public"} />
         </>
     );
-
 }
 
 export default PublicBuilding;

--- a/frontend/pages/public/building.tsx
+++ b/frontend/pages/public/building.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import BuildingPage from "@/components/building/BuildingPage";
 import BaseHeader from "@/components/header/baseHeader";
 
+
 function PublicBuilding() {
 
     return (
         <>
             <BaseHeader/>
-            <BuildingPage type={""}/>
+            <BuildingPage type={"public"}/>
         </>
     )
 


### PR DESCRIPTION
Log in as a syndic (e.g. sylvian@test.com). Add a public id to a building. Go to the link `http://localhost/public/building?id=<PublicId>`.

Also open that link in incognito (logged out), since this page is meant for users without account.


Closes #398