### PR TITLE
fix websockets nextjs frontend

### DIFF
--- a/nginx/nginx.development.conf
+++ b/nginx/nginx.development.conf
@@ -20,6 +20,10 @@ http {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_redirect off;
 
     server {
         listen 80 default_server;
@@ -42,11 +46,6 @@ http {
         listen 2002;
 
         location / {
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_redirect off;
-
             proxy_pass http://docker-backend$request_uri;
         }
     }


### PR DESCRIPTION
This PR fixes the websocket upgrade for frontend. This used to work, but it wasn't used in the new nginx config.