### PR TITLE
Bugfix list params

### DIFF
--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -139,8 +139,8 @@ class AllUsersView(APIView):
 
     @extend_schema(
         description="GET all users in the database. There is the possibility to filter as well. You can filter on "
-        "various parameters. If the parameter name includes 'list' then you can add multiple entries of "
-        "those in the url.",
+                    "various parameters. If the parameter name includes 'list' then you can add multiple entries of "
+                    "those in the url. For example: ?region-id-list[]=1&region-id-list[]=2&include-role-name-list[]=Admin&",
         parameters=param_docs(
             {
                 "region-id-list": ("Filter by region ids", False, OpenApiTypes.INT),

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -139,8 +139,8 @@ class AllUsersView(APIView):
 
     @extend_schema(
         description="GET all users in the database. There is the possibility to filter as well. You can filter on "
-                    "various parameters. If the parameter name includes 'list' then you can add multiple entries of "
-                    "those in the url. For example: ?region-id-list[]=1&region-id-list[]=2&include-role-name-list[]=Admin&",
+        "various parameters. If the parameter name includes 'list' then you can add multiple entries of "
+        "those in the url. For example: ?region-id-list[]=1&region-id-list[]=2&include-role-name-list[]=Admin&",
         parameters=param_docs(
             {
                 "region-id-list": ("Filter by region ids", False, OpenApiTypes.INT),

--- a/backend/util/request_response_util.py
+++ b/backend/util/request_response_util.py
@@ -59,7 +59,7 @@ def get_boolean_param(request, name, required=False):
 
 
 def get_list_param(request, name, required=False):
-    param = request.GET.getlist(name)
+    param = request.GET.getlist(name + '[]', None)
     if not param:
         if required:
             raise BadRequest(_("The query parameter {name} is required").format(name=name))

--- a/backend/util/request_response_util.py
+++ b/backend/util/request_response_util.py
@@ -59,7 +59,7 @@ def get_boolean_param(request, name, required=False):
 
 
 def get_list_param(request, name, required=False):
-    param = request.GET.getlist(name + '[]', None)
+    param = request.GET.getlist(name + "[]", None)
     if not param:
         if required:
             raise BadRequest(_("The query parameter {name} is required").format(name=name))


### PR DESCRIPTION
List query parameters are usually appended by [] in front-end frameworks. The `getlist` function also takes this into account, but I didn't take this into account. This has now been fixed.