### PR TITLE
Added websockets to student components

### DIFF
--- a/frontend/components/student/PersonalSchedule.tsx
+++ b/frontend/components/student/PersonalSchedule.tsx
@@ -1,13 +1,13 @@
 import ToursList from "@/components/student/toursList";
-import { useEffect, useState } from "react";
-import { getCurrentUser, User } from "@/lib/user";
-import { getToursOfStudent, StudentOnTour, StudentOnTourStringDate } from "@/lib/student-on-tour";
-import { getTour, Tour } from "@/lib/tour";
-import { getRegion, RegionInterface } from "@/lib/region";
-import { datesEqual } from "@/lib/date";
-import { useRouter } from "next/router";
+import {useEffect, useState} from "react";
+import {getCurrentUser, User} from "@/lib/user";
+import {getToursOfStudent, StudentOnTour, StudentOnTourStringDate} from "@/lib/student-on-tour";
+import {getTour, Tour} from "@/lib/tour";
+import {getRegion, RegionInterface} from "@/lib/region";
+import {datesEqual} from "@/lib/date";
+import {useRouter} from "next/router";
 
-export default function PersonalSchedule({ redirectTo }: { redirectTo: string }) {
+export default function PersonalSchedule({redirectTo}: { redirectTo: string }) {
     const router = useRouter();
 
     const [user, setUser] = useState<User | null>(null);
@@ -34,13 +34,11 @@ export default function PersonalSchedule({ redirectTo }: { redirectTo: string })
 
         const nextMonth: Date = new Date();
         nextMonth.setMonth(nextMonth.getMonth() + 1);
-        getToursOfStudent(user.id, { startDate: monthAgo, endDate: nextMonth }).then(async (res) => {
+        getToursOfStudent(user.id, {startDate: monthAgo, endDate: nextMonth}).then(async (res) => {
             // Some cache to recognize duplicate tours (to not do unnecessary requests)
             const t: Record<number, Tour> = {};
             const r: Record<number, RegionInterface> = {};
-
             const data: StudentOnTourStringDate[] = res.data;
-
             for (const rec of data) {
                 // Get the tours & regions of tours where the student was assigned to
                 if (!(rec.tour in t)) {
@@ -64,7 +62,16 @@ export default function PersonalSchedule({ redirectTo }: { redirectTo: string })
             }
             // Get the tours today
             const sot: StudentOnTour[] = data.map((s: StudentOnTourStringDate) => {
-                return { id: s.id, student: s.student, tour: s.tour, date: new Date(s.date) };
+                return {
+                    id: s.id,
+                    student: s.student,
+                    tour: s.tour,
+                    date: new Date(s.date),
+                    completed_tour: s.completed_tour,
+                    started_tour: s.started_tour,
+                    current_building_index: s.current_building_index,
+                    max_building_index: s.max_building_index
+                };
             });
             const today: StudentOnTour[] = sot.filter((s: StudentOnTour) => {
                 const d: Date = s.date;
@@ -95,7 +102,7 @@ export default function PersonalSchedule({ redirectTo }: { redirectTo: string })
         router
             .push({
                 pathname: redirectTo,
-                query: { studentOnTourId },
+                query: {studentOnTourId},
             })
             .then();
     }

--- a/frontend/components/student/PlannedBuildingList.tsx
+++ b/frontend/components/student/PlannedBuildingList.tsx
@@ -4,7 +4,7 @@ import { BuildingInterface, getAddress } from "@/lib/building";
 import { datesEqual } from "@/lib/date";
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { getStudentOnTour, StudentOnTour, StudentOnTourStringDate } from "@/lib/student-on-tour";
+import {getStudentOnTour, startStudentOnTour, StudentOnTour, StudentOnTourStringDate} from "@/lib/student-on-tour";
 import { getBuildingsOfTour, getTour, Tour } from "@/lib/tour";
 import { getRegion, RegionInterface } from "@/lib/region";
 
@@ -56,18 +56,34 @@ export default function PlannedBuildingList({
                 student: sots.student,
                 tour: sots.tour,
                 date: new Date(sots.date),
+                max_building_index: sots.max_building_index,
+                current_building_index: sots.current_building_index,
+                started_tour: sots.started_tour,
+                completed_tour: sots.completed_tour,
             });
         }, console.error);
     }, [studentOnTourId]);
 
     async function routeToFirstBuilding() {
-        if (buildings.length === 0) {
+        if (buildings.length === 0 || ! studentOnTourId) {
             return;
         }
-        await router.push({
-            pathname: redirectTo,
-            query: { studentOnTourId: studentOnTour?.id },
-        });
+        startStudentOnTour(studentOnTourId).then(async _ => {
+            await router.push({
+                pathname: redirectTo,
+                query: {studentOnTourId: studentOnTour?.id},
+            });
+        }, console.error);
+    }
+
+    function getStartButtonText() {
+        if (! studentOnTour) {
+            return "";
+        }
+        if (studentOnTour.started_tour && ! studentOnTour.completed_tour) {
+            return "Doe verder met deze ronde";
+        }
+        return "Start deze ronde";
     }
 
     return (
@@ -118,7 +134,7 @@ export default function PlannedBuildingList({
                 <div className="mt-1">
                     {(studentOnTour ? datesEqual(new Date(), studentOnTour?.date) : false) && (
                         <Button variant="primary" className="btn-dark" onClick={() => routeToFirstBuilding().then()}>
-                            Start deze ronde
+                            {getStartButtonText()}
                         </Button>
                     )}
                     {studentOnTour &&
@@ -129,8 +145,8 @@ export default function PlannedBuildingList({
                             )}`}</p>
                         )}
                     {studentOnTour &&
-                        !datesEqual(new Date(), studentOnTour.date) &&
-                        new Date() > studentOnTour.date && (
+                        ((!datesEqual(new Date(), studentOnTour.date) &&
+                        new Date() > studentOnTour.date) || studentOnTour.completed_tour) && (
                             <p>{`U hebt deze ronde afgewerkt op ${studentOnTour.date.toLocaleDateString("en-GB")}.`}</p>
                         )}
                 </div>

--- a/frontend/lib/building.ts
+++ b/frontend/lib/building.ts
@@ -103,7 +103,6 @@ export function getDurationFromMinutes(durationInMinutes: number) {
 
 export const getNewPublicId = async () => {
     const request_url: string = `${process.env.NEXT_PUBLIC_BASE_API_URL}${process.env.NEXT_PUBLIC_API_GET_NEW_PUBLIC_ID_BUILDING}`;
-    console.log(request_url)
     return await api.get(request_url)
 }
 

--- a/frontend/lib/student-on-tour.ts
+++ b/frontend/lib/student-on-tour.ts
@@ -7,6 +7,10 @@ export interface StudentOnTour {
     tour: number;
     date: Date;
     student: number;
+    completed_tour: string | null;
+    started_tour: string | null;
+    max_building_index: number;
+    current_building_index: number;
 }
 
 export interface StudentOnTourStringDate {
@@ -14,6 +18,10 @@ export interface StudentOnTourStringDate {
     tour: number;
     date: string;
     student: number;
+    completed_tour: string | null;
+    started_tour: string | null;
+    max_building_index: number;
+    current_building_index: number;
 }
 
 export async function postStudentOnTour(tour: number, student: number, date: string): Promise<AxiosResponse<any>> {
@@ -55,4 +63,14 @@ export async function getAllStudentOnTourFromToday() {
 export async function getProgress(studentOnTourId: number){
     const request_url = "";
     return 0.5;
+}
+
+export async function startStudentOnTour(studentOnTourId: number) {
+    const post_url: string= `${process.env.NEXT_PUBLIC_BASE_API_URL}${process.env.NEXT_PUBLIC_API_STUDENT_ON_TOUR}${studentOnTourId}/start/`;
+    return await api.post(post_url);
+}
+
+export async function endStudentOnTour(studentOnTourId: number) {
+    const post_url: string= `${process.env.NEXT_PUBLIC_BASE_API_URL}${process.env.NEXT_PUBLIC_API_STUDENT_ON_TOUR}${studentOnTourId}/end/`;
+    return await api.post(post_url);
 }

--- a/frontend/pages/admin/communication.tsx
+++ b/frontend/pages/admin/communication.tsx
@@ -164,7 +164,6 @@ function AdminCommunication() {
                                     /\n/g,
                                     "%0D%0A"
                                 )}`}
-                                onClick={() => console.log()}
                                 style={{ textDecoration: "underline", color: "royalblue" }}
                             >
                                 Verstuur mail


### PR DESCRIPTION
This pr adds the websockets to the student pages.
This allows:
- When refreshing the `student/working/` page to set the right building.
- Post start/end to a tour when a student clicks the start/ finish button.

After finishing a tour, a student is not allowed to make changes anymore.
