### PR TITLE
Potential fix for the failed github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Build Docker
         run: docker-compose build
+        with:
+          files: |
+            .env
 
       - name: Run Tests
         run: |


### PR DESCRIPTION
Potentially you need to define the file that this docker-compose requires to find the ENVIRONEMENT. Let's see what this does to the github tests.