### PR TITLE
Remove end-tour

### DIFF
--- a/frontend/components/student/workingView.tsx
+++ b/frontend/components/student/workingView.tsx
@@ -5,26 +5,26 @@ import {
     RemarkAtBuilding,
     remarkTypes,
 } from "@/lib/remark-at-building";
-import React, {useEffect, useState} from "react";
-import {endStudentOnTour, getStudentOnTour, StudentOnTour, StudentOnTourStringDate} from "@/lib/student-on-tour";
-import {FileListElement, Progress} from "@/types";
-import {BuildingInterface} from "@/lib/building";
-import {getBuildingsOfTour} from "@/lib/tour";
+import React, { useEffect, useState } from "react";
+import { endStudentOnTour, getStudentOnTour, StudentOnTour, StudentOnTourStringDate } from "@/lib/student-on-tour";
+import { FileListElement, Progress } from "@/types";
+import { BuildingInterface } from "@/lib/building";
+import { getBuildingsOfTour } from "@/lib/tour";
 import {
     getPictureOfRemarkOfSpecificRemark,
     getPicturePath,
     PictureOfRemarkInterface,
     postPictureOfRemark,
 } from "@/lib/picture-of-remark";
-import {Apartment, ArrowBack, ArrowForward, AssignmentTurnedIn, Comment} from "@mui/icons-material";
-import {useRouter} from "next/router";
+import { Apartment, ArrowBack, ArrowForward, AssignmentTurnedIn, Comment } from "@mui/icons-material";
+import { useRouter } from "next/router";
 import RemarkModal from "@/components/student/remarkModal";
 import BuildingInfoView from "@/components/student/buildingInfoView";
 import ErrorMessageAlert from "@/components/errorMessageAlert";
-import {Button, ButtonGroup, Form} from "react-bootstrap";
-import {FileList} from "@/components/student/fileList";
+import { Button, ButtonGroup, Form } from "react-bootstrap";
+import { FileList } from "@/components/student/fileList";
 
-export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string; studentOnTourId: number | null }) {
+export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: string; studentOnTourId: number | null }) {
     const router = useRouter();
 
     const typeNames: string[] = ["Aankomst", "Binnen", "Vertrek"];
@@ -86,8 +86,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                 setStudentOnTour(sot);
                 getBuildingsOnTour(sots.tour);
             })
-            .catch((_) => {
-            });
+            .catch((_) => {});
     }, [studentOnTourId]);
 
     useEffect(() => {
@@ -105,8 +104,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                 const bot: BuildingInterface[] = res.data;
                 setBuildingsOnTour(bot);
             })
-            .catch((_) => {
-            });
+            .catch((_) => {});
     }
 
     // Get the buildingInfo at the currentIndex
@@ -135,8 +133,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                     setGlobalRemarks([]);
                 }
             })
-            .catch((_) => {
-            });
+            .catch((_) => {});
     }
 
     // Get the remark of a step
@@ -172,12 +169,10 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                                 })
                             );
                         })
-                        .catch((_) => {
-                        });
+                        .catch((_) => {});
                 }
             })
-            .catch((_) => {
-            });
+            .catch((_) => {});
     }
 
     // Handle the submit event
@@ -221,8 +216,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                     });
                     increaseStep();
                 })
-                .catch((_) => {
-                });
+                .catch((_) => {});
         }
     }
 
@@ -256,7 +250,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                     getGlobalRemarksOfBuilding(b.id);
                 }
                 setProgress((prevState) => {
-                    const newState: Progress = {...prevState};
+                    const newState: Progress = { ...prevState };
                     newState.step = newStep;
                     newState.currentIndex = newIndex;
                     return newState;
@@ -270,7 +264,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
             const newStep = progress.step + 1;
             getRemarkInfo(building.id, newStep);
             setProgress((prevState) => {
-                const newState: Progress = {...prevState};
+                const newState: Progress = { ...prevState };
                 newState.step = newStep;
                 return newState;
             });
@@ -290,7 +284,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                 getGlobalRemarksOfBuilding(b.id);
             }
             setProgress((prevState) => {
-                const newState: Progress = {...prevState};
+                const newState: Progress = { ...prevState };
                 newState.step = newStep;
                 newState.currentIndex = newIndex;
                 return newState;
@@ -302,7 +296,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
             const newStep = progress.step - 1;
             getRemarkInfo(building.id, newStep);
             setProgress((prevState) => {
-                const newState: Progress = {...prevState};
+                const newState: Progress = { ...prevState };
                 newState.step = newStep;
                 return newState;
             });
@@ -344,10 +338,12 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
 
     // Redirect to the schedule page
     function redirectToSchedule(studentOnTourId: number): void {
-        router.push({
-            pathname: redirectTo,
-            query: {studentOnTourId},
-        }).then();
+        router
+            .push({
+                pathname: redirectTo,
+                query: { studentOnTourId },
+            })
+            .then();
     }
 
     /**
@@ -355,29 +351,29 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
      */
     function getNextStepIcon() {
         if (progress.currentIndex === progress.maxIndex && progress.step === 2) {
-            return <AssignmentTurnedIn/>;
+            return <AssignmentTurnedIn />;
         }
         if (progress.step === 2) {
             return (
                 <>
-                    <Apartment/>
-                    <ArrowForward/>
+                    <Apartment />
+                    <ArrowForward />
                 </>
             );
         }
-        return <ArrowForward/>;
+        return <ArrowForward />;
     }
 
     function getPreviousStepIcon() {
         if (progress.step === 0) {
             return (
                 <>
-                    <ArrowBack/>
-                    <Apartment/>
+                    <ArrowBack />
+                    <Apartment />
                 </>
             );
         }
-        return <ArrowBack/>;
+        return <ArrowBack />;
     }
 
     return (
@@ -399,7 +395,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                     currentIndex={progress.currentIndex}
                     amountOfBuildings={buildingsOnTour.length}
                 />
-                <ErrorMessageAlert errorMessages={errorMessages} setErrorMessages={setErrorMessages}/>
+                <ErrorMessageAlert errorMessages={errorMessages} setErrorMessages={setErrorMessages} />
                 <Form onSubmit={handleSubmit} className="mt-2 mb-2">
                     <span className="h5 fw-bold mt-2">{typeNames[progress.step]}</span>
                     <Form.Group className="mb-2 mt-2">
@@ -412,7 +408,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                         />
                     </Form.Group>
 
-                    <FileList files={picturesAtStep} setFiles={setPicturesAtStep} optional={false} editable/>
+                    <FileList files={picturesAtStep} setFiles={setPicturesAtStep} optional={false} editable />
 
                     <ButtonGroup className="d-flex gap-0 m-0" role="group">
                         {(progress.step > 0 || progress.currentIndex > 0) && (
@@ -427,7 +423,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                             </Button>
                         )}
                         <Button variant="primary" className="btn-dark" onClick={() => setShowRemarkModal(true)}>
-                            <Comment/>
+                            <Comment />
                         </Button>
                         <Button variant="primary" className="btn-dark" type="submit">
                             {getNextStepIcon()}
@@ -441,7 +437,7 @@ export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string;
                             {globalRemarks.map((remark, index) => (
                                 <li key={index}>
                                     <a
-                                        style={{color: "royalblue"}}
+                                        style={{ color: "royalblue" }}
                                         onClick={() => {
                                             setSelectedGlobalRemark(remark);
                                             setShowRemarkModal(true);

--- a/frontend/components/student/workingView.tsx
+++ b/frontend/components/student/workingView.tsx
@@ -5,26 +5,26 @@ import {
     RemarkAtBuilding,
     remarkTypes,
 } from "@/lib/remark-at-building";
-import React, { useEffect, useState } from "react";
-import { endStudentOnTour, getStudentOnTour, StudentOnTour, StudentOnTourStringDate } from "@/lib/student-on-tour";
-import { FileListElement, Progress } from "@/types";
-import { BuildingInterface } from "@/lib/building";
-import { getBuildingsOfTour } from "@/lib/tour";
+import React, {useEffect, useState} from "react";
+import {endStudentOnTour, getStudentOnTour, StudentOnTour, StudentOnTourStringDate} from "@/lib/student-on-tour";
+import {FileListElement, Progress} from "@/types";
+import {BuildingInterface} from "@/lib/building";
+import {getBuildingsOfTour} from "@/lib/tour";
 import {
     getPictureOfRemarkOfSpecificRemark,
     getPicturePath,
     PictureOfRemarkInterface,
     postPictureOfRemark,
 } from "@/lib/picture-of-remark";
-import { Apartment, ArrowBack, ArrowForward, AssignmentTurnedIn, Comment } from "@mui/icons-material";
-import { useRouter } from "next/router";
+import {Apartment, ArrowBack, ArrowForward, AssignmentTurnedIn, Comment} from "@mui/icons-material";
+import {useRouter} from "next/router";
 import RemarkModal from "@/components/student/remarkModal";
 import BuildingInfoView from "@/components/student/buildingInfoView";
 import ErrorMessageAlert from "@/components/errorMessageAlert";
-import { Button, ButtonGroup, Form } from "react-bootstrap";
-import { FileList } from "@/components/student/fileList";
+import {Button, ButtonGroup, Form} from "react-bootstrap";
+import {FileList} from "@/components/student/fileList";
 
-export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: string; studentOnTourId: number | null }) {
+export function WorkingView({redirectTo, studentOnTourId}: { redirectTo: string; studentOnTourId: number | null }) {
     const router = useRouter();
 
     const typeNames: string[] = ["Aankomst", "Binnen", "Vertrek"];
@@ -86,7 +86,8 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                 setStudentOnTour(sot);
                 getBuildingsOnTour(sots.tour);
             })
-            .catch((_) => {});
+            .catch((_) => {
+            });
     }, [studentOnTourId]);
 
     useEffect(() => {
@@ -104,7 +105,8 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                 const bot: BuildingInterface[] = res.data;
                 setBuildingsOnTour(bot);
             })
-            .catch((_) => {});
+            .catch((_) => {
+            });
     }
 
     // Get the buildingInfo at the currentIndex
@@ -133,7 +135,8 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                     setGlobalRemarks([]);
                 }
             })
-            .catch((_) => {});
+            .catch((_) => {
+            });
     }
 
     // Get the remark of a step
@@ -169,10 +172,12 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                                 })
                             );
                         })
-                        .catch((_) => {});
+                        .catch((_) => {
+                        });
                 }
             })
-            .catch((_) => {});
+            .catch((_) => {
+            });
     }
 
     // Handle the submit event
@@ -216,7 +221,8 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                     });
                     increaseStep();
                 })
-                .catch((_) => {});
+                .catch((_) => {
+                });
         }
     }
 
@@ -250,7 +256,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                     getGlobalRemarksOfBuilding(b.id);
                 }
                 setProgress((prevState) => {
-                    const newState: Progress = { ...prevState };
+                    const newState: Progress = {...prevState};
                     newState.step = newStep;
                     newState.currentIndex = newIndex;
                     return newState;
@@ -264,7 +270,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
             const newStep = progress.step + 1;
             getRemarkInfo(building.id, newStep);
             setProgress((prevState) => {
-                const newState: Progress = { ...prevState };
+                const newState: Progress = {...prevState};
                 newState.step = newStep;
                 return newState;
             });
@@ -284,7 +290,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                 getGlobalRemarksOfBuilding(b.id);
             }
             setProgress((prevState) => {
-                const newState: Progress = { ...prevState };
+                const newState: Progress = {...prevState};
                 newState.step = newStep;
                 newState.currentIndex = newIndex;
                 return newState;
@@ -296,7 +302,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
             const newStep = progress.step - 1;
             getRemarkInfo(building.id, newStep);
             setProgress((prevState) => {
-                const newState: Progress = { ...prevState };
+                const newState: Progress = {...prevState};
                 newState.step = newStep;
                 return newState;
             });
@@ -338,13 +344,10 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
 
     // Redirect to the schedule page
     function redirectToSchedule(studentOnTourId: number): void {
-        endStudentOnTour(studentOnTourId).catch(() => {});
-        router
-            .push({
-                pathname: redirectTo,
-                query: { studentOnTourId },
-            })
-            .then();
+        router.push({
+            pathname: redirectTo,
+            query: {studentOnTourId},
+        }).then();
     }
 
     /**
@@ -352,29 +355,29 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
      */
     function getNextStepIcon() {
         if (progress.currentIndex === progress.maxIndex && progress.step === 2) {
-            return <AssignmentTurnedIn />;
+            return <AssignmentTurnedIn/>;
         }
         if (progress.step === 2) {
             return (
                 <>
-                    <Apartment />
-                    <ArrowForward />
+                    <Apartment/>
+                    <ArrowForward/>
                 </>
             );
         }
-        return <ArrowForward />;
+        return <ArrowForward/>;
     }
 
     function getPreviousStepIcon() {
         if (progress.step === 0) {
             return (
                 <>
-                    <ArrowBack />
-                    <Apartment />
+                    <ArrowBack/>
+                    <Apartment/>
                 </>
             );
         }
-        return <ArrowBack />;
+        return <ArrowBack/>;
     }
 
     return (
@@ -396,7 +399,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                     currentIndex={progress.currentIndex}
                     amountOfBuildings={buildingsOnTour.length}
                 />
-                <ErrorMessageAlert errorMessages={errorMessages} setErrorMessages={setErrorMessages} />
+                <ErrorMessageAlert errorMessages={errorMessages} setErrorMessages={setErrorMessages}/>
                 <Form onSubmit={handleSubmit} className="mt-2 mb-2">
                     <span className="h5 fw-bold mt-2">{typeNames[progress.step]}</span>
                     <Form.Group className="mb-2 mt-2">
@@ -409,7 +412,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                         />
                     </Form.Group>
 
-                    <FileList files={picturesAtStep} setFiles={setPicturesAtStep} optional={false} editable />
+                    <FileList files={picturesAtStep} setFiles={setPicturesAtStep} optional={false} editable/>
 
                     <ButtonGroup className="d-flex gap-0 m-0" role="group">
                         {(progress.step > 0 || progress.currentIndex > 0) && (
@@ -424,7 +427,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                             </Button>
                         )}
                         <Button variant="primary" className="btn-dark" onClick={() => setShowRemarkModal(true)}>
-                            <Comment />
+                            <Comment/>
                         </Button>
                         <Button variant="primary" className="btn-dark" type="submit">
                             {getNextStepIcon()}
@@ -438,7 +441,7 @@ export function WorkingView({ redirectTo, studentOnTourId }: { redirectTo: strin
                             {globalRemarks.map((remark, index) => (
                                 <li key={index}>
                                     <a
-                                        style={{ color: "royalblue" }}
+                                        style={{color: "royalblue"}}
                                         onClick={() => {
                                             setSelectedGlobalRemark(remark);
                                             setShowRemarkModal(true);


### PR DESCRIPTION
Removes the `student-on-tour/end/`-call, this is now done in the backend when the last `VE` remark is posted.