### PR TITLE
Bugfix: `/analysis/student-on-tour/`

### DIFF
--- a/backend/analysis/serializers.py
+++ b/backend/analysis/serializers.py
@@ -54,6 +54,9 @@ class StudentOnTourAnalysisSerializer(serializers.BaseSerializer):
         building_data = {}
 
         for rab in remarks_at_buildings:
+            # skip if the building was deleted
+            if not rab.building:
+                continue
             # get the building id for the current RemarkAtBuilding object
             building_id = rab.building.id
             # add a dict if we haven't seen this building before


### PR DESCRIPTION
I came accros a bug where the analysis endpoint for a specific `student-on-tour` gave me an `internal server error 500`. I deleted a building that the `student-on-tour` had done. I added these lines in the analysis serializer to fix this.