### PR TITLE
Better UX/UI of remarks and pictures on building info page (fixes #433)

### DIFF
--- a/frontend/components/ImageEnlargeModal.tsx
+++ b/frontend/components/ImageEnlargeModal.tsx
@@ -1,0 +1,40 @@
+import {CloseButton, Modal} from "react-bootstrap";
+
+function ImageEnlargeModal(
+    {
+        show,
+        setShow,
+        imageURL
+    }: {
+        show: boolean,
+        setShow: (a: boolean) => void,
+        imageURL: string
+    }) {
+
+    const handleClose = () => setShow(false);
+
+    return <>
+        <Modal show={show} onHide={handleClose} fullscreen={"xl-down"}>
+            <div className={"bg-black"}
+                 style={{maxHeight: "fit-content", maxWidth: "fit-content", position: "absolute", right: "0"}}>
+                <CloseButton
+                    variant={"white"}
+                    onClick={handleClose}
+                />
+            </div>
+
+            <div style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center"
+            }}>
+                <img src={imageURL} alt={imageURL}
+                     style={{maxHeight: "100%", maxWidth: "100%", height: "70%", width: "auto"}}/>
+            </div>
+        </Modal>
+    </>
+
+}
+
+export default ImageEnlargeModal;
+

--- a/frontend/components/building/BuildingPage.tsx
+++ b/frontend/components/building/BuildingPage.tsx
@@ -1,18 +1,19 @@
-import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
-import { BuildingInterface, getBuildingInfo, getBuildingInfoByPublicId } from "@/lib/building";
-import { AxiosResponse } from "axios/index";
+import {useRouter} from "next/router";
+import React, {useEffect, useState} from "react";
+import {BuildingInterface, getBuildingInfo, getBuildingInfoByPublicId} from "@/lib/building";
+import {AxiosResponse} from "axios/index";
 import BuildingInfo from "@/components/building/buildingComponents/BuildingInfo";
-import LatestCollectionDetail from "@/components/building/buildingComponents/LatestCollectionDetail";
 import LatestCollections from "@/components/building/buildingComponents/LatestCollections";
+import CollectionCards from "@/components/building/buildingComponents/CollectionCards";
 
-interface ParsedUrlQuery {}
+interface ParsedUrlQuery {
+}
 
 interface DashboardQuery extends ParsedUrlQuery {
     id?: string;
 }
 
-function BuildingPage({ type }: { type: "syndic" | "admin" | "public" }) {
+function BuildingPage({type}: { type: "syndic" | "admin" | "public" }) {
     const router = useRouter();
     const query = router.query as DashboardQuery;
 
@@ -46,19 +47,17 @@ function BuildingPage({ type }: { type: "syndic" | "admin" | "public" }) {
         fetchBuilding();
     }, [query.id]);
 
-    // https://www.figma.com/proto/9yLULhNn8b8SlsWlOnRSpm/SeLab2-mockup?node-id=16-1310&scaling=contain&page-id=0%3A1&starting-point-node-id=118%3A1486
-
     return (
         <>
-            <div style={{ display: "flex" }}>
-                <div style={{ flex: "1" }}>
-                    <BuildingInfo building={building} setBuilding={setBuilding} type={type} />
+            <div style={{display: "flex", justifyContent: "space-evenly"}}>
+                <div style={{flex: "1"}}>
+                    <BuildingInfo building={building} setBuilding={setBuilding} type={type}/>
                 </div>
-                <div style={{ flex: "1" }}>
-                    <LatestCollectionDetail building={building ? building.id : 0} />
+                <div style={{flex: "1"}}>
+                    <CollectionCards building={building ? building.id : 0}/>
                 </div>
-                <div style={{ flex: "1" }}>
-                    <LatestCollections building={building ? building.id : 0} />
+                <div style={{flex: "1"}}>
+                    <LatestCollections building={building ? building.id : 0}/>
                 </div>
             </div>
         </>

--- a/frontend/components/building/BuildingPage.tsx
+++ b/frontend/components/building/BuildingPage.tsx
@@ -6,16 +6,15 @@ import BuildingInfo from "@/components/building/buildingComponents/BuildingInfo"
 import LatestCollections from "@/components/building/buildingComponents/LatestCollections";
 import CollectionCards from "@/components/building/buildingComponents/CollectionCards";
 
-interface ParsedUrlQuery {
-}
 
-interface DashboardQuery extends ParsedUrlQuery {
+interface BuildingQuery {
     id?: string;
+    date?: string;
 }
 
 function BuildingPage({type}: { type: "syndic" | "admin" | "public" }) {
     const router = useRouter();
-    const query = router.query as DashboardQuery;
+    const query = router.query as BuildingQuery;
 
     // @ts-ignore
     const [building, setBuilding] = useState<BuildingInterface>(null);
@@ -54,7 +53,7 @@ function BuildingPage({type}: { type: "syndic" | "admin" | "public" }) {
                     <BuildingInfo building={building} setBuilding={setBuilding} type={type}/>
                 </div>
                 <div style={{flex: "1"}}>
-                    <CollectionCards building={building ? building.id : 0}/>
+                    <CollectionCards building={building ? building.id : 0} date={query.date ? query.date : null}/>
                 </div>
                 <div style={{flex: "1"}}>
                     <LatestCollections building={building ? building.id : 0}/>

--- a/frontend/components/building/buildingComponents/CollectionCards.tsx
+++ b/frontend/components/building/buildingComponents/CollectionCards.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useState } from "react";
+import {useEffect, useState} from "react";
 import {
     getRemarksAtBuildingOfSpecificBuilding,
     RemarkAtBuildingInterface,
     translateRemarkAtBuildingType,
 } from "@/lib/remark-at-building";
-import { getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface } from "@/lib/picture-of-remark";
-import { Accordion, Card } from "react-bootstrap";
+import {getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface} from "@/lib/picture-of-remark";
+import {Accordion, Card} from "react-bootstrap";
 import ImageEnlargeModal from "@/components/ImageEnlargeModal";
 
-function CollectionCards({ building, date }: { building: number; date: string | null }) {
+function CollectionCards({building, date}: { building: number; date: string | null }) {
     const [collectionDetails, setCollectionDetails] = useState<
         [RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] | []
     >([]);
@@ -65,29 +65,40 @@ function CollectionCards({ building, date }: { building: number; date: string | 
                         Details ophaling op datum '{date}' (dit werkt nog niet, maar gebruik in jullie code gerust al de
                         link met de query param)
                     </h4>
-                    <br />
+                    <br/>
                 </>
             )}
 
-            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL} />
+            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL}/>
 
             <h1>Details laatste ophaling</h1>
-            <div style={{ margin: "0 0", width: "75%", maxWidth: "95%" }}>
+            <div style={{margin: "0 0", width: "75%", maxWidth: "95%"}}>
                 {collectionDetails.length == 0}
                 <Accordion alwaysOpen>
                     {collectionDetails.map(([remark, pictures]) => (
                         <Accordion.Item eventKey={remark.id + ""} key={remark.id}>
                             <Accordion.Header>{translateRemarkAtBuildingType(remark.type)}</Accordion.Header>
                             <Accordion.Body>
-                                <Card.Subtitle className="mb-2 text-muted">{remark.timestamp + ""}</Card.Subtitle>
+                                <Card.Subtitle className="mb-2 text-muted">{
+                                    new Date(remark.timestamp + "").toLocaleString('nl-BE', {
+                                        weekday: 'long',
+                                        day: 'numeric',
+                                        month: 'long',
+                                        year: 'numeric',
+                                        hour: 'numeric',
+                                        minute: 'numeric',
+                                        timeZone: 'Europe/Brussels',
+                                        timeZoneName: 'short'
+                                    })
+                                }</Card.Subtitle>
                                 <Card.Text>{remark.remark}</Card.Text>
                                 <div>
-                                    {pictures.map((picture) => (
+                                    {pictures.map((picture: PictureOfRemarkInterface) => (
                                         <Card.Img
                                             key={picture.id}
                                             src={`${("" + process.env.NEXT_PUBLIC_BASE_API_URL).slice(0, -1)}${
                                                 picture.picture
-                                            }`} // Update the base URL accordingly
+                                            }`}
                                             alt="Remark picture"
                                             style={{
                                                 maxHeight: "15em",

--- a/frontend/components/building/buildingComponents/CollectionCards.tsx
+++ b/frontend/components/building/buildingComponents/CollectionCards.tsx
@@ -1,17 +1,17 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 import {
     getRemarksAtBuildingOfSpecificBuilding,
     RemarkAtBuildingInterface,
     translateRemarkAtBuildingType,
 } from "@/lib/remark-at-building";
-import {getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface} from "@/lib/picture-of-remark";
-import {Accordion, Card} from "react-bootstrap";
+import { getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface } from "@/lib/picture-of-remark";
+import { Accordion, Card } from "react-bootstrap";
 import ImageEnlargeModal from "@/components/ImageEnlargeModal";
 
-function CollectionCards({building, date}: { building: number, date: string | null }) {
-
-    const [collectionDetails, setCollectionDetails] = useState<[RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] | []>([]);
-
+function CollectionCards({ building, date }: { building: number; date: string | null }) {
+    const [collectionDetails, setCollectionDetails] = useState<
+        [RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] | []
+    >([]);
 
     const [enlargeImageShow, setEnlargeImageShow] = useState<boolean>(false);
     const [enlargeImageURL, setEnlargeImageURL] = useState<string>("");
@@ -59,16 +59,20 @@ function CollectionCards({building, date}: { building: number, date: string | nu
 
     return (
         <>
-            {date &&
-                <><h4>Details ophaling op datum '{date}' (dit werkt nog niet, maar gebruik in jullie code gerust al de
-                    link
-                    met de query param)</h4><br/></>}
+            {date && (
+                <>
+                    <h4>
+                        Details ophaling op datum '{date}' (dit werkt nog niet, maar gebruik in jullie code gerust al de
+                        link met de query param)
+                    </h4>
+                    <br />
+                </>
+            )}
 
-            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL}/>
-
+            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL} />
 
             <h1>Details laatste ophaling</h1>
-            <div style={{margin: "0 0", width: "75%", maxWidth: "95%"}}>
+            <div style={{ margin: "0 0", width: "75%", maxWidth: "95%" }}>
                 {collectionDetails.length == 0}
                 <Accordion alwaysOpen>
                     {collectionDetails.map(([remark, pictures]) => (

--- a/frontend/components/building/buildingComponents/CollectionCards.tsx
+++ b/frontend/components/building/buildingComponents/CollectionCards.tsx
@@ -1,0 +1,118 @@
+import {useEffect, useState} from "react";
+import {
+    getRemarksAtBuildingOfSpecificBuilding,
+    RemarkAtBuildingInterface,
+    translateRemarkAtBuildingType
+} from "@/lib/remark-at-building";
+import {getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface} from "@/lib/picture-of-remark";
+import {Accordion, Card} from "react-bootstrap";
+import ImageEnlargeModal from "@/components/ImageEnlargeModal";
+
+
+function CollectionCards({building}: { building: number }) {
+
+    const [collectionDetails, setCollectionDetails] = useState<[RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] | []>([]);
+
+    const [enlargeImageShow, setEnlargeImageShow] = useState<boolean>(false);
+    const [enlargeImageURL, setEnlargeImageURL] = useState<string>("");
+
+
+    useEffect(() => {
+
+
+        getRemarksAtBuildingOfSpecificBuilding(building, true)
+            .then((response) => {
+
+                const responseData: RemarkAtBuildingInterface[] = response.data.sort((a: RemarkAtBuildingInterface, b: RemarkAtBuildingInterface) => {
+                    for (let t of ["AA", "BI", "VE", "OP"]) {
+                        if (a.type == t) {
+                            return -1;
+                        }
+                        if (b.type == t) {
+                            return 1;
+                        }
+                    }
+                });
+
+                const fetchPictures = responseData.map((remark) =>
+                    getPictureOfRemarkOfSpecificRemark(remark.id)
+                );
+
+                Promise.all(fetchPictures)
+                    .then((responses) => {
+
+                        const pictureData: PictureOfRemarkInterface[][] = responses.map(
+                            (response) => response.data
+                        );
+
+                        const newCollectionDetails: [RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] =
+                            responseData.map(
+                                (remark, index) => [
+                                    remark,
+                                    pictureData[index],
+                                ]);
+
+                        setCollectionDetails(newCollectionDetails);
+
+                    })
+                    .catch((error) => {
+                        console.error(error);
+                    });
+
+            })
+            .catch((error) => {
+                console.error(error);
+            });
+
+    }, [building]);
+
+    function imageClick(url: string) {
+        setEnlargeImageURL(url);
+        setEnlargeImageShow(true);
+    }
+
+    return (
+        <>
+            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL}/>
+
+            <h1>Details laatste ophaling</h1>
+            <div style={{margin: "0 0", width: "75%", maxWidth: "95%"}}>
+                {collectionDetails.length == 0}
+                <Accordion alwaysOpen>
+                    {collectionDetails.map(([remark, pictures]) => (
+                        <Accordion.Item eventKey={remark.id + ""} key={remark.id}>
+                            <Accordion.Header>
+                                {translateRemarkAtBuildingType(remark.type)}
+                            </Accordion.Header>
+                            <Accordion.Body>
+                                <Card.Subtitle className="mb-2 text-muted">
+                                    {remark.timestamp + ''}
+                                </Card.Subtitle>
+                                <Card.Text>{remark.remark}</Card.Text>
+                                <div>
+                                    {pictures.map(picture => (
+                                        <Card.Img
+                                            key={picture.id}
+                                            src={`${("" + process.env.NEXT_PUBLIC_BASE_API_URL).slice(0, -1)}${picture.picture}`} // Update the base URL accordingly
+                                            alt="Remark picture"
+                                            style={{
+                                                maxHeight: '15em',
+                                                width: "auto",
+                                                maxWidth: "95%",
+                                                cursor: "pointer"
+                                            }}
+                                            onClick={() => imageClick(`${("" + process.env.NEXT_PUBLIC_BASE_API_URL).slice(0, -1)}${picture.picture}`)}
+                                        />
+                                    ))}
+                                </div>
+                            </Accordion.Body>
+                        </Accordion.Item>
+                    ))}
+                </Accordion>
+            </div>
+        </>
+    );
+
+}
+
+export default CollectionCards;

--- a/frontend/components/building/buildingComponents/CollectionCards.tsx
+++ b/frontend/components/building/buildingComponents/CollectionCards.tsx
@@ -1,14 +1,14 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 import {
     getRemarksAtBuildingOfSpecificBuilding,
     RemarkAtBuildingInterface,
     translateRemarkAtBuildingType,
 } from "@/lib/remark-at-building";
-import {getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface} from "@/lib/picture-of-remark";
-import {Accordion, Card} from "react-bootstrap";
+import { getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface } from "@/lib/picture-of-remark";
+import { Accordion, Card } from "react-bootstrap";
 import ImageEnlargeModal from "@/components/ImageEnlargeModal";
 
-function CollectionCards({building, date}: { building: number; date: string | null }) {
+function CollectionCards({ building, date }: { building: number; date: string | null }) {
     const [collectionDetails, setCollectionDetails] = useState<
         [RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] | []
     >([]);
@@ -65,32 +65,32 @@ function CollectionCards({building, date}: { building: number; date: string | nu
                         Details ophaling op datum '{date}' (dit werkt nog niet, maar gebruik in jullie code gerust al de
                         link met de query param)
                     </h4>
-                    <br/>
+                    <br />
                 </>
             )}
 
-            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL}/>
+            <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL} />
 
             <h1>Details laatste ophaling</h1>
-            <div style={{margin: "0 0", width: "75%", maxWidth: "95%"}}>
+            <div style={{ margin: "0 0", width: "75%", maxWidth: "95%" }}>
                 {collectionDetails.length == 0}
                 <Accordion alwaysOpen>
                     {collectionDetails.map(([remark, pictures]) => (
                         <Accordion.Item eventKey={remark.id + ""} key={remark.id}>
                             <Accordion.Header>{translateRemarkAtBuildingType(remark.type)}</Accordion.Header>
                             <Accordion.Body>
-                                <Card.Subtitle className="mb-2 text-muted">{
-                                    new Date(remark.timestamp + "").toLocaleString('nl-BE', {
-                                        weekday: 'long',
-                                        day: 'numeric',
-                                        month: 'long',
-                                        year: 'numeric',
-                                        hour: 'numeric',
-                                        minute: 'numeric',
-                                        timeZone: 'Europe/Brussels',
-                                        timeZoneName: 'short'
-                                    })
-                                }</Card.Subtitle>
+                                <Card.Subtitle className="mb-2 text-muted">
+                                    {new Date(remark.timestamp + "").toLocaleString("nl-BE", {
+                                        weekday: "long",
+                                        day: "numeric",
+                                        month: "long",
+                                        year: "numeric",
+                                        hour: "numeric",
+                                        minute: "numeric",
+                                        timeZone: "Europe/Brussels",
+                                        timeZoneName: "short",
+                                    })}
+                                </Card.Subtitle>
                                 <Card.Text>{remark.remark}</Card.Text>
                                 <div>
                                     {pictures.map((picture: PictureOfRemarkInterface) => (

--- a/frontend/components/building/buildingComponents/CollectionCards.tsx
+++ b/frontend/components/building/buildingComponents/CollectionCards.tsx
@@ -9,7 +9,7 @@ import {Accordion, Card} from "react-bootstrap";
 import ImageEnlargeModal from "@/components/ImageEnlargeModal";
 
 
-function CollectionCards({building}: { building: number }) {
+function CollectionCards({building, date}: { building: number, date: string | null }) {
 
     const [collectionDetails, setCollectionDetails] = useState<[RemarkAtBuildingInterface, PictureOfRemarkInterface[]][] | []>([]);
 
@@ -73,6 +73,11 @@ function CollectionCards({building}: { building: number }) {
 
     return (
         <>
+            {date &&
+                <><h4>Details ophaling op datum '{date}' (dit werkt nog niet, maar gebruik in jullie code gerust al de
+                    link
+                    met de query param)</h4><br/></>}
+
             <ImageEnlargeModal show={enlargeImageShow} setShow={setEnlargeImageShow} imageURL={enlargeImageURL}/>
 
             <h1>Details laatste ophaling</h1>

--- a/frontend/components/building/buildingComponents/LatestCollectionDetail TODO:VERWIJDEREN.tsx
+++ b/frontend/components/building/buildingComponents/LatestCollectionDetail TODO:VERWIJDEREN.tsx
@@ -2,12 +2,23 @@ import { useEffect, useState } from "react";
 import {
     getRemarksAtBuildingOfSpecificBuilding,
     RemarkAtBuildingInterface,
-    translateRemartAtBuildingType,
+    translateRemarkAtBuildingType,
 } from "@/lib/remark-at-building";
 import { Card } from "react-bootstrap";
 import { getPictureOfRemarkOfSpecificRemark, PictureOfRemarkInterface } from "@/lib/picture-of-remark";
 
-function LatestCollectionDetail({ building }: { building: number }) {
+
+
+
+
+// wordt niet meer gebruikt, maar nog ff laten staan voor als ik code zou nodig hebben
+
+
+
+
+
+
+function LatestCollectionDetailTODOVERWIJDEREN({ building }: { building: number }) {
     const [remarks, setRemarks] = useState<RemarkAtBuildingInterface[]>([]);
     const [pictures, setPictures] = useState<string[]>([]);
     const [date, setDate] = useState<Date | undefined>();
@@ -87,7 +98,7 @@ function LatestCollectionDetail({ building }: { building: number }) {
                 return (
                     <Card key={remark.id}>
                         <Card.Body>
-                            <Card.Title>{translateRemartAtBuildingType(remark.type)}</Card.Title>
+                            <Card.Title>{translateRemarkAtBuildingType(remark.type)}</Card.Title>
                             <Card.Subtitle>{remark.timestamp ? String(remark.timestamp) : ""}</Card.Subtitle>
                             <Card.Text>{remark.remark || "Geen opmerkingen"}</Card.Text>
                         </Card.Body>
@@ -98,4 +109,4 @@ function LatestCollectionDetail({ building }: { building: number }) {
     );
 }
 
-export default LatestCollectionDetail;
+export default LatestCollectionDetailTODOVERWIJDEREN;

--- a/frontend/lib/remark-at-building.ts
+++ b/frontend/lib/remark-at-building.ts
@@ -10,7 +10,7 @@ export interface RemarkAtBuildingInterface {
     type: "AA" | "BI" | "VE" | "OP";
 }
 
-export function translateRemartAtBuildingType(type: RemarkAtBuildingInterface["type"]) {
+export function translateRemarkAtBuildingType(type: RemarkAtBuildingInterface["type"]) {
     switch (type) {
         case "AA":
             return "Aankomst";
@@ -19,7 +19,7 @@ export function translateRemartAtBuildingType(type: RemarkAtBuildingInterface["t
         case "VE":
             return "Vertrek";
         case "OP":
-            return "Opmerking";
+            return "Algemene Opmerking";
     }
 }
 

--- a/frontend/pages/admin/dashboard.tsx
+++ b/frontend/pages/admin/dashboard.tsx
@@ -14,7 +14,7 @@ import { BuildingOnTour, getAllBuildingsOnTourWithTourID } from "@/lib/building-
 import {
     getRemarksAtBuildingOfSpecificBuilding,
     RemarkAtBuildingInterface,
-    translateRemartAtBuildingType,
+    translateRemarkAtBuildingType,
 } from "@/lib/remark-at-building";
 
 const GreenLinearProgress = styled(LinearProgress)(() => ({
@@ -57,7 +57,7 @@ function AdminDashboard() {
                         // don't actually care about the remark, just the count
                         const remarks: RemarkAtBuildingInterface[] = remarkRes.data;
                         for (const remark of remarks) {
-                            if (translateRemartAtBuildingType(remark.type) === "Opmerking") {
+                            if (translateRemarkAtBuildingType(remark.type) === "Algemene Opmerking") {
                                 remarksCount++;
                             }
                         }


### PR DESCRIPTION
Fixes #433.


Now I have better code to do #432

------------------------------------------------------------

# how to test:

 http://localhost/syndic/building?id=7&date=abcd

* 7 is a building on tour "UGent Campussen" of syndic Sylvian (address is Krijgslaan 281)
* So add a new "Planning" to a student, let the student upload some pictures (7 is the first building on that tour)
* Enjoy the new building info page  http://localhost/syndic/building?id=7&date=abcd




This is a rather small interim PR, I think one reviewer is enough. If everything is ready I'll ask review of everyone. But for now, you can at least kinda use the query parameter in your code as you two requested in the meeting yesterday.

 