### PR TITLE
Fix that brings signals back

### DIFF
--- a/backend/base/apps.py
+++ b/backend/base/apps.py
@@ -6,4 +6,5 @@ class BaseConfig(AppConfig):
     name = "base"
 
     def ready(self):
-        pass
+        # noinspection PyUnresolvedReferences
+        import base.signals


### PR DESCRIPTION
The import was optimised during a code cleanup. However we need this import to stay. This should now always be the case.

#486 