### PR TITLE
Validation of date so a student can't be planned on a passed date

### DIFF
--- a/backend/base/models.py
+++ b/backend/base/models.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import date
+from datetime import date, datetime
 
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.contrib.auth.models import PermissionsMixin
@@ -313,7 +313,11 @@ class StudentOnTour(models.Model):
 
     def clean(self):
         super().clean()
-
+        if self.date and self.date < datetime.now().date():
+            raise ValidationError(
+                # TODO translation
+                _("You cannot plan a student on a past date.")
+            )
         if self.student_id and self.tour_id:
             user = self.student
             if user.role.name.lower() == "syndic":

--- a/backend/student_on_tour/views.py
+++ b/backend/student_on_tour/views.py
@@ -126,7 +126,6 @@ class StudentOnTourBulk(APIView):
         }
         """
         for d in data["ids"]:
-            print(d)
             student_on_tour_instance = StudentOnTour.objects.filter(id=d).first()
             if not student_on_tour_instance:
                 return not_found("StudentOnTour")
@@ -165,13 +164,10 @@ class StudentOnTourBulk(APIView):
         }
         """
         for StudentOnTour_id in data:
-            print(StudentOnTour_id)
             student_on_tour_instance = StudentOnTour.objects.filter(id=StudentOnTour_id).first()
             if not student_on_tour_instance:
                 return not_found("StudentOnTour")
-            print(student_on_tour_instance)
             set_keys_of_instance(student_on_tour_instance, data[StudentOnTour_id], TRANSLATE)
-            print(student_on_tour_instance)
             if r := try_full_clean_and_save(student_on_tour_instance):
                 return r
 


### PR DESCRIPTION
This PR adds date validation in the clean method of StudentOnTour so that an admin or superstudent can't plan a student on a date that has already passed.

The translation of the error message is missing, but should be fixed with https://github.com/SELab-2/Dr-Trottoir-4/issues/483

closes #353 