### PR TITLE
add min-height for rbc-event

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -274,6 +274,10 @@
     word-wrap: break-word;
 }
 
+.rbc-event {
+    min-height: 60px;
+}
+
 /* Style for all icons */
 .icon {
     display: inline-block;


### PR DESCRIPTION
Fixes the "n meer" issue for calendar by setting a `min-height`, this was removed by the styling pr.

Then:
![image](https://github.com/SELab-2/Dr-Trottoir-4/assets/77171450/aec9d729-77c2-4bcc-a579-f4efd42a110c)

Now:
![image](https://github.com/SELab-2/Dr-Trottoir-4/assets/77171450/322bec93-562d-4c4e-b997-e479f9bdfd6c)
